### PR TITLE
fix allocation bug using the wrong status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mctl"
-version = "0.3.0"
+version = "0.4.0"
 description = "mctl"
 authors = ["naps-dev"]
 readme = "README.md"

--- a/src/cli/cmds/group_one.py
+++ b/src/cli/cmds/group_one.py
@@ -41,23 +41,26 @@ def allocate_from_pool(config, pool_name, tags, count):
 
     POOL_NAME is the name of the pool where servers should be allocated
     """
-    machines = config.client.machines.list()
+    try:
+        machines = config.client.machines.list()
 
-    pool_machines = utils.get_machines_by_pool_name(machines, [pool_name])
+        pool_machines = utils.get_machines_by_pool_name(machines, [pool_name])
 
-    if tags:
-        pool_machines = utils.get_machines_by_tags(pool_machines, tags.split(","))
+        if tags:
+            pool_machines = utils.get_machines_by_tags(pool_machines, tags.split(","))
 
-    filtered_machines = list(
-        filter(
-            lambda machine: machine.status_message in ["Ready", "Released"],
-            pool_machines,
+        filtered_machines = list(
+            filter(
+                lambda machine: machine.status_name in ["Ready", "Released"],
+                pool_machines,
+            )
         )
-    )
 
-    selected_machines = utils.select_random_machines(count, filtered_machines)
-    utils.allocate_machines(selected_machines)
-    click.echo(",".join([machine.hostname for machine in selected_machines]))
+        selected_machines = utils.select_random_machines(count, filtered_machines)
+        utils.allocate_machines(selected_machines)
+        click.echo(",".join([machine.hostname for machine in selected_machines]))
+    except Exception as e:
+        click.echo(f"An error occurred: {e}")
 
 
 @click.command()

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -3,6 +3,7 @@ import contextlib
 import random
 import socket
 import string
+import sys
 import time
 
 import click
@@ -43,7 +44,9 @@ def select_random_machines(n, machines):
         list: A list of n randomly selected machines.
     """
     if n > len(machines):
-        raise ValueError("n cannot be greater than the number of machines in the list")
+        raise ValueError(
+            f"Unable to allocate {n} machines, only {len(machines)} available"
+        )
 
     return random.sample(machines, n)
 
@@ -249,9 +252,13 @@ def wait_for_port(host, port, timeout=60):
 
 
 def allocate_machines(machines):
-    client = _get_client()
-    for machine in machines:
-        client.machines.allocate(hostname=machine.hostname)
+    try:
+        client = _get_client()
+        for machine in machines:
+            client.machines.allocate(hostname=machine.hostname)
+    except Exception as e:
+        click.echo(f"Error allocating machine {machine.hostname}: {e}")
+        sys.exit(1)
 
 
 def deploy_servers(machines, token, ip_addresses):


### PR DESCRIPTION
This PR fixes a bug with allocating machines caused by checking the wrong status field on the returned machine objects.