### PR TITLE
add node-type label when deploying clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Deploying clusters now adds node labels with the machine tier to each node. The label name is `node-type` and the value the Tier Tag from MAAS. (e.g. "Tier1")
+- Deploying clusters now adds node labels with the machine tier to each node. The label name is `cnaps.io/node-type` and the value the Tier Tag from MAAS. (e.g. "Tier-1")
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Deploying clusters now adds node labels with the machine tier to each node. The label name is `node-type` and the value the Tier Tag from MAAS. (e.g. "Tier1")
 
-- TBD
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Deprecated
+
+### Breaking
+
 
 ## [0.5.0] - 2023-05-10
 

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -163,7 +163,6 @@ def get_rke_token():
 
 
 def get_server_cloud_init(token, ip_addresses, node_type):
-    # - '\curl -sfL https://get.rke2.io | INSTALL_RKE2_VERSION=$RKE2_VERSION sh -'
     primary_server_cloud_init = f"""
 #cloud-config
 write_files:

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -1,5 +1,6 @@
 import base64
 import contextlib
+import json
 import os
 import random
 import socket
@@ -175,8 +176,8 @@ write_files:
       token: {token}
       disable-cloud-controller: true
       write-kubeconfig-mode: 644
-      node-label: {node_labels}
-      node-taint: {node_taints}
+      node-label: {json.dumps(node_labels)}
+      node-taint: {json.dumps(node_taints)}
       disable:
         - "rke2-ingress-nginx"
 
@@ -196,8 +197,8 @@ write_files:
       token: {token}
       disable-cloud-controller: true
       write-kubeconfig-mode: 644
-      node-label: {node_labels}
-      node-taint: {node_taints}
+      node-label: {json.dumps(node_labels)}
+      node-taint: {json.dumps(node_taints)}
       disable:
         - "rke2-ingress-nginx"
 
@@ -219,8 +220,8 @@ write_files:
       server: https://{ip_addresses[0]}:9345
       token: {token}
       write-kubeconfig-mode: 644
-      node-label: {node_labels}
-      node-taint: {node_taints}
+      node-label: {json.dumps(node_labels)}
+      node-taint: {json.dumps(node_taints)}
 
 runcmd:
  - 'sudo bash -c "/opt/setup.sh agent | tee /tmp/setup.log"'
@@ -276,7 +277,7 @@ def deploy_servers(machines, token, ip_addresses):
         for tag in tags:
             tag_name = tag.name
             if tag_name.startswith("LABEL_"):
-                _, label_name, label_value = tag_name.split("_", 3)
+                _, label_name, label_value = tag_name.split("_", 2)
                 label_string = f"cnaps.io/{label_name}={label_value}"
                 label_strings.append(label_string)
         return label_strings
@@ -288,13 +289,12 @@ def deploy_servers(machines, token, ip_addresses):
             tag_name = tag.name
             if tag_name.startswith("TAINT_"):
                 _, taint_name, taint_value, taint_effect = tag_name.split("_", 3)
-                taint_string = f"cnaps.io/{taint_name}={taint_value}:{effect}"
+                taint_string = f"cnaps.io/{taint_name}={taint_value}:{taint_effect}"
                 taint_strings.append(taint_string)
 
         return taint_strings
 
     click.echo("Deploying Servers:")
-    # print(server_cloud_init)
     for primary in machines[:1]:
         primary_labels = get_node_labels(primary.tags)
         primary_taints = get_node_taints(primary.tags)

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -276,8 +276,8 @@ def deploy_servers(machines, token, ip_addresses):
         for tag in tags:
             tag_name = tag.name
             if tag_name.startswith("LABEL_"):
-                suffix = tag_name.split("_", 1)[1]
-                label_string = "cnaps.io/" + suffix.replace("_", "=")
+                _, label_name, label_value = tag_name.split("_", 3)
+                label_string = f"cnaps.io/{label_name}={label_value}"
                 label_strings.append(label_string)
         return label_strings
 

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -287,10 +287,7 @@ def deploy_servers(machines, token, ip_addresses):
         for tag in tags:
             tag_name = tag.name
             if tag_name.startswith("TAINT_"):
-                split_string = tag_name.split("_")
-                taint_name = split_string[1]
-                taint_value = split_string[2]
-                effect = split_string[4]
+                _, taint_name, taint_value, taint_effect = tag_name.split("_", 3)
                 taint_string = f"cnaps.io/{taint_name}={taint_value}:{effect}"
                 taint_strings.append(taint_string)
 

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -176,7 +176,7 @@ write_files:
       disable-cloud-controller: true
       write-kubeconfig-mode: 644
       node-label:
-        - "node-type={node_type}"
+        - "hardware-tier={node_type}"
       disable:
         - "rke2-ingress-nginx"
 
@@ -197,7 +197,7 @@ write_files:
       disable-cloud-controller: true
       write-kubeconfig-mode: 644
       node-label:
-        - "node-type={node_type}"
+        - "hardware-tier={node_type}"
       disable:
         - "rke2-ingress-nginx"
 
@@ -221,7 +221,7 @@ write_files:
       token: {token}
       write-kubeconfig-mode: 644
       node-label:
-        - "node-type={node_type}"
+        - "hardware-tier={node_type}"
 
 runcmd:
  - 'sudo bash -c "/opt/setup.sh agent | tee /tmp/setup.log"'


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Description

This PR depends on MAAS tags defined according to the following convention:

| MAAS Value | RKE  Label | RKE taint |
|--------|--------|--------|
| LABEL_node-type_Tier-1 | cnaps.io/node-type=Tier-1 |-|
| TAINT_node-taint_noncore_NoSchedule | - |cnaps.io/node-class=noncore:NoSchedule|


Currently, when deploying a cluster, node labels and taints are not included in the RKE2 config. This PR changes that behavior, and after deploying a cluster, the nodes will then have a label named `cnaps.io/node-type` with the Tier tag value from MAAS (e.g. "LABEL_node-type_Tier-1"). 

Additionally, this PR adds the ability to pass taint values from MAAS tags to RKE agents. If a taint tag exists on the MAAS machine instance in the form of `TAINT_node-taint_noncore_NoSchedule` the tag will be parsed into an RKE formatted taint and assigned to the node/server in the form of `TAINT_node-taint_noncore_NoSchedule` 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Deployed Cluster to test node, retrieved the kubeconfig, and ran: 
       - `kubectl get no --show-labels` to check for the `cnaps.io/node-type=Tier-1` label
       - `kubectl describe node` to check if a taint existed for `cnaps.io/node-class=noncore:NoSchedule`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added a plain language explanation of the changes to the Unreleased section of the CHANGELOG.md file

