### PR TITLE
support for renaming interfaces based on tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Deploying clusters now adds node labels with the machine tier to each node. The label name is `cnaps.io/node-type` and the value the Tier Tag from MAAS. (e.g. "Tier-1")
 
 ### Changed
 
@@ -23,9 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 
+## [0.7.0] - 2023-06-28
+
+### Added
+- Experimental support for renaming network interfaces based on tags set in MaaS. This is done by adding a tag to the network interface of the machine in MaaS. This feature only supports the tag `capture` and renames the tagged interface to `capture0`.
+
 ## [0.6.0] - 2023-06-14
 
 ### Added
+- Deploying clusters now adds node labels with the machine tier to each node. The label name is `cnaps.io/node-type` and the value is set via the corresponding label from MAAS. (e.g. "Tier-1")
 - Taints and tolerations are now added to RKE cluster based on tags setup in MaaS
 
 ## [0.5.0] - 2023-05-10
@@ -54,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workflow to run code quality checks on the cli code
  
 [unreleased]: https://github.com/naps-dev/maas-ctl/compare/v0.6.0...HEAD
+[0.7.0]: https://github.com/naps-dev/maas-ctl/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/naps-dev/maas-ctl/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/naps-dev/maas-ctl/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/naps-dev/maas-ctl/releases/tag/v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mctl"
-version = "0.6.0"
+version = "0.7.0"
 description = "mctl"
 authors = ["naps-dev"]
 readme = "README.md"

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -326,8 +326,6 @@ def deploy_servers(machines, token, ip_addresses):
             hwe_kernel="generic",
         )
         wait_for_machine_status(secondary, ["Deployed", "Failed deployment"])
-        wait_for_port(secondary.ip_addresses[0], 22, 120)
-        wait_for_port(secondary.ip_addresses[0], 6443, 300)
 
 
 def deploy_agents(machines, token, ip_addresses):

--- a/src/cli/libs/utils.py
+++ b/src/cli/libs/utils.py
@@ -417,7 +417,7 @@ def set_interface_names(machine):
     for interface in machine.interfaces:
         if "capture" in interface.tags:
             # Get a copy of the tags because changing the name of the interface resets the tags
-            interface_tags = interface.tags[0:]
+            interface_tags = interface.tags[:]
             interface.name = "capture0"
             interface.save()
 


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
This PR adds support for renaming a machine's network interfaces based on tags set on the respective network interface in MaaS. This PR only supports the tag `capture` which renames the interface to `capture0`. 

# How Has This Been Tested?

Starting with a machine in the `Ready` state, a network interface was selected as the capture interface. For example, `enp196s0f0` was selected and a tag was added with the value of `capture`. Then using `mctl` the machine was deployed as a stand-alone cluster using the command `mctl machines deploy-cluster --servers atar1`. After deployment, the name of the interface was verified to be `capture0` after logging into the deployed server.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added a plain language explanation of the changes to the Unreleased section of the CHANGELOG.md file

